### PR TITLE
Fix language block selection

### DIFF
--- a/js/language_switcher_update.js
+++ b/js/language_switcher_update.js
@@ -1,5 +1,10 @@
 document.addEventListener("DOMContentLoaded", function() {
-  const links = document.querySelectorAll("#block-languageswitcher a");
+  let links = document.querySelectorAll("#block-islandora-muni-languageswitcher a");
+
+  // arnenovak and cinematicbrno have different block id
+  if (!links) {
+    links = document.querySelectorAll("#block-languageswitcher a");
+  }
 
   links.forEach(link => {
     let url = new URL(link.href); 


### PR DESCRIPTION
Sites arnenovak and cinematicbrno have different block id's, probably due to them being built before islandora-muni theme was a thing.